### PR TITLE
Melhoria arquivo de apikeys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# arquivo de credenciais
+credentials.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # arquivo de credenciais
 credentials.json
+
+# virtual environments
+venv
+.venv

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # trade_bot_binance
 Siga a sequência de passos a seguir para usar o "trade_bot"
 
-**Passo 1**: Crie uma sua API de gerenciamento na Binance
+**Passo 1**: Crie uma sua API de gerenciamento na Binance ([detalhes aqui](https://www.binance.com/en/support/faq/360002502072))
 
 **Passo 2**: Baixe os arquivos desse repositório
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@ Siga a sequência de passos a seguir para usar o "trade_bot"
 
 **Passo 1**: Baixe os arquivos desse repositório.
 
-**Passo 2**: Crie uma sua API de gerenciamento na Binance ([detalhes aqui](https://www.binance.com/en/support/faq/360002502072)). Não esqueça de habilitar a opção _Enable Spot & Margin Trading_ e, de preferência, limitar o uso apenas para o seu IP. Guarde as credenciais no arquivo `credentials.json`.
+**Passo 2**: Crie uma sua API de gerenciamento na Binance ([detalhes aqui](https://www.binance.com/en/support/faq/360002502072)). Não esqueça de habilitar a opção _Enable Spot & Margin Trading_ e, de preferência, limitar o uso apenas para o seu IP. Guarde as credenciais no arquivo `credentials.json`, no formato 
+```
+{
+    "API_KEY":  "XYZ", 
+    "API_SECRET": "XYZ"
+}
+```
 
 **Passo 4**: Em seguida rode o arquivo principal "main_unit.py", ou execute o arquivo executável "execultavel.bat".
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # trade_bot_binance
 Siga a sequência de passos a seguir para usar o "trade_bot"
 
-**Passo 1**: Crie uma sua API de gerenciamento na Binance ([detalhes aqui](https://www.binance.com/en/support/faq/360002502072)). Não esqueça de habilitar a opção _Enable Spot & Margin Trading_ e, de preferência, limitar o uso apenas para o seu IP. Guarde as credenciais no arquivo `credentials.json`.
+**Passo 1**: Baixe os arquivos desse repositório.
 
-**Passo 2**: Baixe os arquivos desse repositório
+**Passo 2**: Crie uma sua API de gerenciamento na Binance ([detalhes aqui](https://www.binance.com/en/support/faq/360002502072)). Não esqueça de habilitar a opção _Enable Spot & Margin Trading_ e, de preferência, limitar o uso apenas para o seu IP. Guarde as credenciais no arquivo `credentials.json`.
 
-**Passo 3**: Após baixar os arquivos, insira sua chave da API da Binance no arquivo "config_My_API.py". 
-
-**Passo 4**: Em seguida rode o arquivo principal "main_unit.py", ou execute o arquivo "execultavel.bat".
+**Passo 4**: Em seguida rode o arquivo principal "main_unit.py", ou execute o arquivo executável "execultavel.bat".
 
 **Obs 1**: As bibliotecas necessárias estão no arquivo "requiriments.txt".
 
+**Obs 2**: Rentabilidade passada não é garantia de rentabilidade futura
 
 **Disclaimer**:
 Nada assegura que a estratégia de investimento contida nesse robô(código) são adequadas ao perfil e circunstâncias individuais de quem o recebe.
@@ -19,5 +18,5 @@ Investimentos envolvem riscos e os investidores devem ter prudência ao tomar su
 Este documento não pode ser reproduzido ou distribuído por qualquer pessoa, parcialmente ou em sua totalidade, sem o prévio consentimento
 por escrito do Autor. 
 
-**Obs 2**: Rentabilidade passada não é garantia de rentabilidade futura
+
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # trade_bot_binance
 Siga a sequência de passos a seguir para usar o "trade_bot"
 
-**Passo 1**: Crie uma sua API de gerenciamento na Binance ([detalhes aqui](https://www.binance.com/en/support/faq/360002502072))
+**Passo 1**: Crie uma sua API de gerenciamento na Binance ([detalhes aqui](https://www.binance.com/en/support/faq/360002502072)). Não esqueça de habilitar a opção _Enable Spot & Margin Trading_ e, de preferência, limitar o uso apenas para o seu IP. Guarde as credenciais no arquivo `credentials.json`.
 
 **Passo 2**: Baixe os arquivos desse repositório
 

--- a/config_My_API.py
+++ b/config_My_API.py
@@ -1,2 +1,0 @@
-api_key= ''
-api_secret= ''

--- a/main_unit.py
+++ b/main_unit.py
@@ -15,11 +15,11 @@ import os.path
 import pandas as pd
 from datetime import datetime
 import pytz
-import config_My_API
+import json
 
 
-
-client_binance= Client(api_key=config_My_API.api_key, api_secret=config_My_API.api_secret)
+credentials =  json.load(open(f"./credentials.json"))
+client_binance= Client(api_key=credentials.get("API_KEY"), api_secret=credentials.get("API_SECRET"))
 
 
 class Main(QtWidgets.QMainWindow):     


### PR DESCRIPTION
Sugestão de melhorias na coleta de api keys. Para padronizar e evitar versionar sem querer uma versão das credenciais com elas inclusas, subindo no github, um padrão bastante usado é puxar as credenciais de um json não versionado. No caso, deixei em um `credentials.json` nesse formato:

```
{
    "API_KEY":  "XYZ", 
    "API_SECRET": "XYZ"
}
```

Mudanças:

- [x] adiciona gitignore para não versionar dados de credenciais, nem pastas comuns como de ambiente virtual para quem usar (ex: `venv/`)
- [x] altera a coleta das credenciais para pegar do json
- [x] atualiza README