### PR TITLE
Add logs e timestamps + outras melhorias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# arquivo de credenciais
+credentials.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # arquivo de credenciais
 credentials.json
+
+# virtual environments
+venv
+.venv

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # trade_bot_binance
 Siga a sequência de passos a seguir para usar o "trade_bot"
 
-**Passo 1**: Crie uma sua API de gerenciamento na Binance
+**Passo 1**: Crie uma sua API de gerenciamento na Binance ([detalhes aqui](https://www.binance.com/en/support/faq/360002502072))
 
 **Passo 2**: Baixe os arquivos desse repositório
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@ Siga a sequência de passos a seguir para usar o "trade_bot"
 
 **Passo 1**: Baixe os arquivos desse repositório.
 
-**Passo 2**: Crie uma sua API de gerenciamento na Binance ([detalhes aqui](https://www.binance.com/en/support/faq/360002502072)). Não esqueça de habilitar a opção _Enable Spot & Margin Trading_ e, de preferência, limitar o uso apenas para o seu IP. Guarde as credenciais no arquivo `credentials.json`.
+**Passo 2**: Crie uma sua API de gerenciamento na Binance ([detalhes aqui](https://www.binance.com/en/support/faq/360002502072)). Não esqueça de habilitar a opção _Enable Spot & Margin Trading_ e, de preferência, limitar o uso apenas para o seu IP. Guarde as credenciais no arquivo `credentials.json`, no formato 
+```
+{
+    "API_KEY":  "XYZ", 
+    "API_SECRET": "XYZ"
+}
+```
 
 **Passo 4**: Em seguida rode o arquivo principal "main_unit.py", ou execute o arquivo executável "execultavel.bat".
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # trade_bot_binance
 Siga a sequência de passos a seguir para usar o "trade_bot"
 
-**Passo 1**: Crie uma sua API de gerenciamento na Binance ([detalhes aqui](https://www.binance.com/en/support/faq/360002502072)). Não esqueça de habilitar a opção _Enable Spot & Margin Trading_ e, de preferência, limitar o uso apenas para o seu IP. Guarde as credenciais no arquivo `credentials.json`.
+**Passo 1**: Baixe os arquivos desse repositório.
 
-**Passo 2**: Baixe os arquivos desse repositório
+**Passo 2**: Crie uma sua API de gerenciamento na Binance ([detalhes aqui](https://www.binance.com/en/support/faq/360002502072)). Não esqueça de habilitar a opção _Enable Spot & Margin Trading_ e, de preferência, limitar o uso apenas para o seu IP. Guarde as credenciais no arquivo `credentials.json`.
 
-**Passo 3**: Após baixar os arquivos, insira sua chave da API da Binance no arquivo "config_My_API.py". 
-
-**Passo 4**: Em seguida rode o arquivo principal "main_unit.py", ou execute o arquivo "execultavel.bat".
+**Passo 4**: Em seguida rode o arquivo principal "main_unit.py", ou execute o arquivo executável "execultavel.bat".
 
 **Obs 1**: As bibliotecas necessárias estão no arquivo "requiriments.txt".
 
+**Obs 2**: Rentabilidade passada não é garantia de rentabilidade futura
 
 **Disclaimer**:
 Nada assegura que a estratégia de investimento contida nesse robô(código) são adequadas ao perfil e circunstâncias individuais de quem o recebe.
@@ -19,5 +18,5 @@ Investimentos envolvem riscos e os investidores devem ter prudência ao tomar su
 Este documento não pode ser reproduzido ou distribuído por qualquer pessoa, parcialmente ou em sua totalidade, sem o prévio consentimento
 por escrito do Autor. 
 
-**Obs 2**: Rentabilidade passada não é garantia de rentabilidade futura
+
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # trade_bot_binance
 Siga a sequência de passos a seguir para usar o "trade_bot"
 
-**Passo 1**: Crie uma sua API de gerenciamento na Binance ([detalhes aqui](https://www.binance.com/en/support/faq/360002502072))
+**Passo 1**: Crie uma sua API de gerenciamento na Binance ([detalhes aqui](https://www.binance.com/en/support/faq/360002502072)). Não esqueça de habilitar a opção _Enable Spot & Margin Trading_ e, de preferência, limitar o uso apenas para o seu IP. Guarde as credenciais no arquivo `credentials.json`.
 
 **Passo 2**: Baixe os arquivos desse repositório
 

--- a/coloredlogs.py
+++ b/coloredlogs.py
@@ -1,0 +1,37 @@
+import logging
+logging.basicConfig(
+    format='%(asctime)s %(levelname)-8s %(message)s',
+    level=logging.INFO,
+    datefmt='%Y-%m-%d %H:%M:%S')
+
+class CustomFormatter(logging.Formatter):
+
+    grey = "\x1b[38;20m"
+    yellow = "\x1b[33;20m"
+    red = "\x1b[31;20m"
+    bold_red = "\x1b[31;1m"
+    reset = "\x1b[0m"
+    format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
+
+    FORMATS = {
+        logging.DEBUG: grey + format + reset,
+        logging.INFO: grey + format + reset,
+        logging.WARNING: yellow + format + reset,
+        logging.ERROR: red + format + reset,
+        logging.CRITICAL: bold_red + format + reset
+    }
+
+    def format(self, record):
+        log_fmt = self.FORMATS.get(record.levelno)
+        formatter = logging.Formatter(log_fmt)
+        return formatter.format(record)
+
+    def get_colored_logger(self):
+        logger = logging.getLogger("Trading Bot")
+        # create console handler with a higher log level
+        ch = logging.StreamHandler()
+        ch.setLevel(logging.INFO)
+        ch.setFormatter(CustomFormatter())
+        logger.addHandler(ch)
+        
+        return logger

--- a/config_My_API.py
+++ b/config_My_API.py
@@ -1,2 +1,0 @@
-api_key= ''
-api_secret= ''

--- a/functions.py
+++ b/functions.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import requests
 from tradingview_ta import TA_Handler, Interval, Exchange
@@ -11,11 +10,13 @@ from pip._internal import main as install
 import os.path
 from datetime import datetime
 import pytz
+
 # Import module
 import threading
 import time
+
 # Importar bibliotecas necessárias da binance
-from binance.exceptions import BinanceAPIException # here
+from binance.exceptions import BinanceAPIException  # here
 from binance.helpers import round_step_size
 from binance.client import Client
 from binance.enums import *
@@ -23,220 +24,314 @@ import pandas as pd
 from math import floor, log
 
 import logging
-logger = logging.getLogger('Trading Bot')
 
-def Map( x,  in_min,  in_max,  out_min,  out_max):
-  return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min
+logger = logging.getLogger("Trading Bot")
+
+
+def Map(x, in_min, in_max, out_min, out_max):
+    return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min
+
 
 def Sentimento_do_mercado(investimento_max):
     try:
         response = requests.get("https://api.alternative.me/fng/?limit=1")
-        data=response.json() # This method is convenient when the API returns JSON
-        #print("Fear and Greed Index:",data['data'][0]['value_classification'],'with',data['data'][0]['value']+'%')
-        caixa= np.round(Map(int(data['data'][0]['value']),1,100,10,investimento_max))
+        data = response.json()  # This method is convenient when the API returns JSON
+        # print("Fear and Greed Index:",data['data'][0]['value_classification'],'with',data['data'][0]['value']+'%')
+        caixa = np.round(
+            Map(int(data["data"][0]["value"]), 1, 100, 10, investimento_max)
+        )
         return caixa
     except (ConnectTimeout, HTTPError, ReadTimeout, Timeout, ConnectionError):
         # loga no console
         logger.exception(f"Erro de conexão. Traceback abaixo.")
-        
-        return investimento_max-50
+
+        return investimento_max - 50
+
 
 # Função para obter os valores floats a partir de strings
-def STR2FLOAT(STR,tick_size):
-    number=re.findall(r"[-+]?\d*\.\d+|\d+", STR)[0]
-    number=float(number)
-    number=round_step_size(number, float(tick_size))
+def STR2FLOAT(STR, tick_size):
+    number = re.findall(r"[-+]?\d*\.\d+|\d+", STR)[0]
+    number = float(number)
+    number = round_step_size(number, float(tick_size))
 
-    #number=float('{:.3f}'.format(number))
-    return number 
+    # number=float('{:.3f}'.format(number))
+    return number
 
-def Venda_trade(arquivo,client_binance,Crypto,Quantity,recommendation,valor_de_compra,trades_finalizados,today):
-    
+
+def Venda_trade(
+    arquivo,
+    client_binance,
+    Crypto,
+    Quantity,
+    recommendation,
+    valor_de_compra,
+    trades_finalizados,
+    today,
+):
+
     logger.info("Vendendo ativo")
     logger.info(f"Quantidade: {Quantity}")
     try:
-        order_ = client_binance.order_market_sell(symbol=Crypto,quantity=Quantity)
-        valor_de_venda=float(order_['fills'][0]['price'])
+        order_ = client_binance.order_market_sell(symbol=Crypto, quantity=Quantity)
+        valor_de_venda = float(order_["fills"][0]["price"])
         logger.info("Valor de venda {valor_de_venda}")
-        porcentagem=(valor_de_venda-valor_de_compra)*100/valor_de_compra
-        
+        porcentagem = (valor_de_venda - valor_de_compra) * 100 / valor_de_compra
+
         logger.info(f"{Crypto}: Tive lucro/preju de: {round(porcentagem, 4)}%")
-        
+
         dia = today.strftime("%d/%m/%Y")
         horario = today.strftime("%H:%M:%S")
-        data_pd={'Crypto':Crypto,'Status':recommendation,'Price':valor_de_venda,'Quantity':Quantity,'Day':dia,'HOUR':horario}
-        trades_finalizados=trades_finalizados.append(data_pd,ignore_index=True)
+        data_pd = {
+            "Crypto": Crypto,
+            "Status": recommendation,
+            "Price": valor_de_venda,
+            "Quantity": Quantity,
+            "Day": dia,
+            "HOUR": horario,
+        }
+        trades_finalizados = trades_finalizados.append(data_pd, ignore_index=True)
         trades_finalizados.to_csv(arquivo, index=False)
         return valor_de_venda, porcentagem
 
     except BinanceAPIException as e:
-        logger.exception(f"Erro da Binance, status code {e.status_code}. Traceback abaixo.")
-        porcentagem=(valor_de_venda-valor_de_compra)*100/valor_de_compra
+        logger.exception(
+            f"Erro da Binance, status code {e.status_code}. Traceback abaixo."
+        )
+        porcentagem = (valor_de_venda - valor_de_compra) * 100 / valor_de_compra
 
-def Trade_bot(Aviso_valor_atual,Set_status,Aviso_valor,Aviso_quantidade,Aviso,client_binance,Crypto,Quantity,preco_atual,temp,today,tradingview, Venda_lucro, recommendation,arquivo, espera, status_trade, trades_finalizados, valor_de_compra, valor_de_venda,Trade,porcentagem,Set_Button_Venda):
-     # try:
+
+def Trade_bot(
+    Aviso_valor_atual,
+    Set_status,
+    Aviso_valor,
+    Aviso_quantidade,
+    Aviso,
+    client_binance,
+    Crypto,
+    Quantity,
+    preco_atual,
+    temp,
+    today,
+    tradingview,
+    Venda_lucro,
+    recommendation,
+    arquivo,
+    espera,
+    status_trade,
+    trades_finalizados,
+    valor_de_compra,
+    valor_de_venda,
+    Trade,
+    porcentagem,
+    Set_Button_Venda,
+):
+    # try:
 
     try:
-        recommendation=tradingview.get_analysis().summary['RECOMMENDATION']
-        preco_atual = float(client_binance.get_avg_price(symbol=Crypto)['price'])
-        Aviso_valor_atual.emit('Preço atual: '+str(preco_atual))
-    
+        recommendation = tradingview.get_analysis().summary["RECOMMENDATION"]
+        preco_atual = float(client_binance.get_avg_price(symbol=Crypto)["price"])
+        Aviso_valor_atual.emit("Preço atual: " + str(preco_atual))
+
     except (ConnectTimeout, HTTPError, ReadTimeout, Timeout, ConnectionError):
         # loga no console
         logger.exception(f"Erro de conexão. Traceback abaixo.")
-        Trade=False
+        Trade = False
         time.sleep(10)
 
-    if 'SELL' in recommendation and (('SELL') in status_trade or ('NEUTRAL') in status_trade):
-        if espera==False:
+    if "SELL" in recommendation and (
+        ("SELL") in status_trade or ("NEUTRAL") in status_trade
+    ):
+        if espera == False:
             logger.info("Esperando oportunidade de compra")
             Set_status.emit(1)
-            Aviso.emit('Esperando oportunidade de compra')
-        espera=True
-        Venda_lucro=False
-        status_trade=recommendation
-        
-    elif 'SELL' in recommendation and 'BUY' in status_trade and Venda_lucro==False:
-        
-        valor_de_venda, porcentagem = Venda_trade(arquivo,client_binance,Crypto,
-                                        Quantity,recommendation,valor_de_compra,
-                                        trades_finalizados,today)
+            Aviso.emit("Esperando oportunidade de compra")
+        espera = True
+        Venda_lucro = False
+        status_trade = recommendation
 
-        Aviso_valor.emit('Valor de venda: '+str(valor_de_venda))
+    elif "SELL" in recommendation and "BUY" in status_trade and Venda_lucro == False:
+
+        valor_de_venda, porcentagem = Venda_trade(
+            arquivo,
+            client_binance,
+            Crypto,
+            Quantity,
+            recommendation,
+            valor_de_compra,
+            trades_finalizados,
+            today,
+        )
+
+        Aviso_valor.emit("Valor de venda: " + str(valor_de_venda))
         Set_status.emit(3)
         Aviso_quantidade.emit(str(0))
         Set_Button_Venda.emit(False)
-        Trade=False
-        espera=False
+        Trade = False
+        espera = False
 
         if tradingview.interval in temp:
-            status_trade=recommendation
-        else:    
-            status_trade='NEUTRAL'
+            status_trade = recommendation
+        else:
+            status_trade = "NEUTRAL"
             tradingview.interval = temp
-            
-        
-    elif 'BUY' in recommendation and 'SELL' in status_trade and Venda_lucro==False:
+
+    elif "BUY" in recommendation and "SELL" in status_trade and Venda_lucro == False:
         logger.info("Comprando ativo")
 
         try:
-            order_ = client_binance.order_market_buy(symbol=Crypto,quantity=Quantity)
-            valor_de_compra=float(order_['fills'][0]['price'])
+            order_ = client_binance.order_market_buy(symbol=Crypto, quantity=Quantity)
+            valor_de_compra = float(order_["fills"][0]["price"])
             logger.info("Valor de compra: {valor_de_compra}")
-            Aviso_valor.emit('Valor de compra: '+str(valor_de_compra))
+            Aviso_valor.emit("Valor de compra: " + str(valor_de_compra))
             Set_status.emit(2)
 
             dia = today.strftime("%d/%m/%Y")
             horario = today.strftime("%H:%M:%S")
-            data_pd={'Crypto':Crypto,'Status':recommendation,'Price':valor_de_compra,'Quantity':Quantity,'Day':dia,'HOUR':horario}
-            trades_finalizados=trades_finalizados.append(data_pd,ignore_index=True)
+            data_pd = {
+                "Crypto": Crypto,
+                "Status": recommendation,
+                "Price": valor_de_compra,
+                "Quantity": Quantity,
+                "Day": dia,
+                "HOUR": horario,
+            }
+            trades_finalizados = trades_finalizados.append(data_pd, ignore_index=True)
             trades_finalizados.to_csv(arquivo, index=False)
-            
-            espera=False
-            status_trade=recommendation
+
+            espera = False
+            status_trade = recommendation
             Set_Button_Venda.emit(True)
 
         except BinanceAPIException as e:
-            logger.exception(f"Erro da Binance, status code {e.status_code}. Traceback abaixo.")
+            logger.exception(
+                f"Erro da Binance, status code {e.status_code}. Traceback abaixo."
+            )
             Aviso.emit(e.message)
-            
-        try: 
+
+        try:
             logger.info(f"Quantidade: {float(order_['origQty'])}")
-            Quantity=float(order_['executedQty'])
+            Quantity = float(order_["executedQty"])
             logger.info(f"Quantidade comprada: {Quantity}")
             logger.info(order_)
 
         except BinanceAPIException as e:
-            logger.exception(f"Erro da Binance, status code {e.status_code}. Traceback abaixo.")
+            logger.exception(
+                f"Erro da Binance, status code {e.status_code}. Traceback abaixo."
+            )
             Aviso.emit(e.message)
-        
+
         Aviso_quantidade.emit(str(Quantity))
 
-    elif 'BUY' in recommendation and 'BUY' in status_trade and Venda_lucro==False:
-        porcentagem=(preco_atual-valor_de_compra)*100/valor_de_compra
-        #print(Crypto+":",'Tive lucro/preju de:',porcentagem,"%")
-        
-        if porcentagem>3 and porcentagem<10:
-            tradingview.interval = '1h'
-        elif porcentagem>10 and porcentagem<17:
-            tradingview.interval = '30m'
-        elif porcentagem>17 and porcentagem<25:
-            tradingview.interval = '15m'
-        elif porcentagem>25:   
-            tradingview.interval = '5m'
-            
-        if porcentagem>=50:
-            Venda_lucro=True
-            status_trade='NEUTRAL'
-            valor_de_venda = Venda_trade(arquivo,client_binance,Crypto,
-                                        Quantity,'SELL',valor_de_compra,
-                                        trades_finalizados,today)
-            Aviso_valor.emit('Valor de venda: '+str(valor_de_venda))
+    elif "BUY" in recommendation and "BUY" in status_trade and Venda_lucro == False:
+        porcentagem = (preco_atual - valor_de_compra) * 100 / valor_de_compra
+        # print(Crypto+":",'Tive lucro/preju de:',porcentagem,"%")
+
+        if porcentagem > 3 and porcentagem < 10:
+            tradingview.interval = "1h"
+        elif porcentagem > 10 and porcentagem < 17:
+            tradingview.interval = "30m"
+        elif porcentagem > 17 and porcentagem < 25:
+            tradingview.interval = "15m"
+        elif porcentagem > 25:
+            tradingview.interval = "5m"
+
+        if porcentagem >= 50:
+            Venda_lucro = True
+            status_trade = "NEUTRAL"
+            valor_de_venda = Venda_trade(
+                arquivo,
+                client_binance,
+                Crypto,
+                Quantity,
+                "SELL",
+                valor_de_compra,
+                trades_finalizados,
+                today,
+            )
+            Aviso_valor.emit("Valor de venda: " + str(valor_de_venda))
             Set_status.emit(3)
             logger.info("Esperando oportunidade de compra")
-            Aviso.emit('Esperando oportunidade de compra')
+            Aviso.emit("Esperando oportunidade de compra")
             Set_status.emit(1)
-            tradingview.interval=temp 
-            
-        if espera==False:
+            tradingview.interval = temp
+
+        if espera == False:
             logger.info("Esperando ativo valorizar mais")
-            Aviso.emit('Esperando ativo valorizar mais')
-            status_trade=recommendation
+            Aviso.emit("Esperando ativo valorizar mais")
+            status_trade = recommendation
             Set_Button_Venda.emit(True)
 
-        espera=True
-    elif 'BUY' in recommendation and 'NEUTRAL' in status_trade and Venda_lucro==False:
-            if espera==False:
-                logger.info("Ativo muito valorizado, estou esperando oportunidade de compra")
-                Aviso.emit('Ativo muito valorizado, estou esperando oportunidade de compra')
-                Set_status.emit(1)
-            espera=True
+        espera = True
+    elif "BUY" in recommendation and "NEUTRAL" in status_trade and Venda_lucro == False:
+        if espera == False:
+            logger.info(
+                "Ativo muito valorizado, estou esperando oportunidade de compra"
+            )
+            Aviso.emit("Ativo muito valorizado, estou esperando oportunidade de compra")
+            Set_status.emit(1)
+        espera = True
     try:
         if valor_de_compra:
             pass
-    except :
-        valor_de_compra=1
-    
-            
-    return Quantity,recommendation, status_trade,Trade, preco_atual,porcentagem, Venda_lucro, espera,valor_de_compra, tradingview
-    
-def main(Set_status,Aviso,client_binance,Crypto,investimento_max,Quantity):
-    valor_do_trade=investimento_max
+    except:
+        valor_de_compra = 1
+
+    return (
+        Quantity,
+        recommendation,
+        status_trade,
+        Trade,
+        preco_atual,
+        porcentagem,
+        Venda_lucro,
+        espera,
+        valor_de_compra,
+        tradingview,
+    )
+
+
+def main(Set_status, Aviso, client_binance, Crypto, investimento_max, Quantity):
+    valor_do_trade = investimento_max
     # verifica o tamanho de casas decimais da crypto
-    tick_size=client_binance.get_symbol_info(Crypto)['filters'][0]['tickSize']
-    preco_medio = float(client_binance.get_avg_price(symbol=Crypto)['price'])
+    tick_size = client_binance.get_symbol_info(Crypto)["filters"][0]["tickSize"]
+    preco_medio = float(client_binance.get_avg_price(symbol=Crypto)["price"])
 
-    #verifica na carteira, a informações sobre o dinheiro em caixa.
-    saldo_usdt=client_binance.get_asset_balance(asset='USDT')
-    saldo_btc=client_binance.get_asset_balance(asset='BTC')
-    if Quantity==0:
-        Quantity_=valor_do_trade/preco_medio
-        #print('Quantidade1:',Quantity_)
-        Quantity=STR2FLOAT(str(Quantity_),tick_size)
-        if Quantity <=0:
-            tick_size=float(tick_size)/100
-            Quantity=STR2FLOAT(str(Quantity_),tick_size)
+    # verifica na carteira, a informações sobre o dinheiro em caixa.
+    saldo_usdt = client_binance.get_asset_balance(asset="USDT")
+    saldo_btc = client_binance.get_asset_balance(asset="BTC")
+    if Quantity == 0:
+        Quantity_ = valor_do_trade / preco_medio
+        # print('Quantidade1:',Quantity_)
+        Quantity = STR2FLOAT(str(Quantity_), tick_size)
+        if Quantity <= 0:
+            tick_size = float(tick_size) / 100
+            Quantity = STR2FLOAT(str(Quantity_), tick_size)
 
-        if Quantity>1 and  Quantity<10 :
-            Quantity=round(Quantity,1)
-        elif Quantity>10:
-            Quantity=floor(Quantity)
-            #Quantity=round(Quantity)
-            
+        if Quantity > 1 and Quantity < 10:
+            Quantity = round(Quantity, 1)
+        elif Quantity > 10:
+            Quantity = floor(Quantity)
+            # Quantity=round(Quantity)
 
     logger.info(f"Quantidade:: {Quantity}")
-    if 'USDT' in Crypto   and float(saldo_usdt['free']) > 1 and valor_do_trade>10:
-         logger.info(f"Iniciando o trade de: {Crypto}, com valor de caixa de: {valor_do_trade}")
-         Trade=True
-         #Trade_bot(Crypto,Quantity)
-    elif 'BTC' in Crypto   and float(saldo_btc['free']) > 0:
-         logger.info(f"Iniciando o trade de: {Crypto}, com valor de caixa de: {valor_do_trade}")
-         Trade=True
-         #Trade_bot(Crypto,Quantity)
-    else: 
-        logger.warning("Saldo insuficiente ou o tamanho da ordem é menor que 10$ usdt ou o par não é com USDT")
-        Aviso.emit('Saldo insuficiente' )
+    if "USDT" in Crypto and float(saldo_usdt["free"]) > 1 and valor_do_trade > 10:
+        logger.info(
+            f"Iniciando o trade de: {Crypto}, com valor de caixa de: {valor_do_trade}"
+        )
+        Trade = True
+        # Trade_bot(Crypto,Quantity)
+    elif "BTC" in Crypto and float(saldo_btc["free"]) > 0:
+        logger.info(
+            f"Iniciando o trade de: {Crypto}, com valor de caixa de: {valor_do_trade}"
+        )
+        Trade = True
+        # Trade_bot(Crypto,Quantity)
+    else:
+        logger.warning(
+            "Saldo insuficiente ou o tamanho da ordem é menor que 10$ usdt ou o par não é com USDT"
+        )
+        Aviso.emit("Saldo insuficiente")
         Set_status.emit(1)
-        Trade= False
-        
-    return  Quantity, Trade, preco_medio
+        Trade = False
+
+    return Quantity, Trade, preco_medio

--- a/functions.py
+++ b/functions.py
@@ -23,12 +23,8 @@ from binance.enums import *
 import pandas as pd
 from math import floor, log
 
-import logging
-logging.basicConfig(
-    format='%(asctime)s %(levelname)-8s %(message)s',
-    level=logging.INFO,
-    datefmt='%Y-%m-%d %H:%M:%S')
-logger = logging.getLogger("Trading Bot")
+from coloredlogs import CustomFormatter
+logger = CustomFormatter().get_colored_logger()
 
 
 def Map(x, in_min, in_max, out_min, out_max) -> int:

--- a/functions.py
+++ b/functions.py
@@ -23,6 +23,7 @@ import pandas as pd
 from math import floor, log
 
 import logging
+logger = logging.getLogger('Trading Bot')
 
 def Map( x,  in_min,  in_max,  out_min,  out_max):
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min
@@ -36,7 +37,7 @@ def Sentimento_do_mercado(investimento_max):
         return caixa
     except (ConnectTimeout, HTTPError, ReadTimeout, Timeout, ConnectionError):
         # loga no console
-        logging.exception(f"Erro de conexão. Traceback abaixo.")
+        logger.exception(f"Erro de conexão. Traceback abaixo.")
         
         return investimento_max-50
 
@@ -51,15 +52,15 @@ def STR2FLOAT(STR,tick_size):
 
 def Venda_trade(arquivo,client_binance,Crypto,Quantity,recommendation,valor_de_compra,trades_finalizados,today):
     
-    logging.INFO("Vendendo ativo")
-    logging.INFO(f"Quantidade: {Quantity}")
+    logger.info("Vendendo ativo")
+    logger.info(f"Quantidade: {Quantity}")
     try:
         order_ = client_binance.order_market_sell(symbol=Crypto,quantity=Quantity)
         valor_de_venda=float(order_['fills'][0]['price'])
-        logging.INFO("Valor de venda {valor_de_venda}")
+        logger.info("Valor de venda {valor_de_venda}")
         porcentagem=(valor_de_venda-valor_de_compra)*100/valor_de_compra
         
-        logging.INFO(f"{Crypto}: Tive lucro/preju de: {round(porcentagem, 4)}%")
+        logger.info(f"{Crypto}: Tive lucro/preju de: {round(porcentagem, 4)}%")
         
         dia = today.strftime("%d/%m/%Y")
         horario = today.strftime("%H:%M:%S")
@@ -69,7 +70,7 @@ def Venda_trade(arquivo,client_binance,Crypto,Quantity,recommendation,valor_de_c
         return valor_de_venda, porcentagem
 
     except BinanceAPIException as e:
-        logging.exception(f"Erro da Binance, status code {e.status_code}. Traceback abaixo.")
+        logger.exception(f"Erro da Binance, status code {e.status_code}. Traceback abaixo.")
         porcentagem=(valor_de_venda-valor_de_compra)*100/valor_de_compra
 
 def Trade_bot(Aviso_valor_atual,Set_status,Aviso_valor,Aviso_quantidade,Aviso,client_binance,Crypto,Quantity,preco_atual,temp,today,tradingview, Venda_lucro, recommendation,arquivo, espera, status_trade, trades_finalizados, valor_de_compra, valor_de_venda,Trade,porcentagem,Set_Button_Venda):
@@ -82,13 +83,13 @@ def Trade_bot(Aviso_valor_atual,Set_status,Aviso_valor,Aviso_quantidade,Aviso,cl
     
     except (ConnectTimeout, HTTPError, ReadTimeout, Timeout, ConnectionError):
         # loga no console
-        logging.exception(f"Erro de conexão. Traceback abaixo.")
+        logger.exception(f"Erro de conexão. Traceback abaixo.")
         Trade=False
         time.sleep(10)
 
     if 'SELL' in recommendation and (('SELL') in status_trade or ('NEUTRAL') in status_trade):
         if espera==False:
-            logging.INFO("Esperando oportunidade de compra")
+            logger.info("Esperando oportunidade de compra")
             Set_status.emit(1)
             Aviso.emit('Esperando oportunidade de compra')
         espera=True
@@ -116,12 +117,12 @@ def Trade_bot(Aviso_valor_atual,Set_status,Aviso_valor,Aviso_quantidade,Aviso,cl
             
         
     elif 'BUY' in recommendation and 'SELL' in status_trade and Venda_lucro==False:
-        logging.INFO("Comprando ativo")
+        logger.info("Comprando ativo")
 
         try:
             order_ = client_binance.order_market_buy(symbol=Crypto,quantity=Quantity)
             valor_de_compra=float(order_['fills'][0]['price'])
-            logging.INFO("Valor de compra: {valor_de_compra}")
+            logger.info("Valor de compra: {valor_de_compra}")
             Aviso_valor.emit('Valor de compra: '+str(valor_de_compra))
             Set_status.emit(2)
 
@@ -136,17 +137,17 @@ def Trade_bot(Aviso_valor_atual,Set_status,Aviso_valor,Aviso_quantidade,Aviso,cl
             Set_Button_Venda.emit(True)
 
         except BinanceAPIException as e:
-            logging.exception(f"Erro da Binance, status code {e.status_code}. Traceback abaixo.")
+            logger.exception(f"Erro da Binance, status code {e.status_code}. Traceback abaixo.")
             Aviso.emit(e.message)
             
         try: 
-            logging.INFO(f"Quantidade: {float(order_['origQty'])}")
+            logger.info(f"Quantidade: {float(order_['origQty'])}")
             Quantity=float(order_['executedQty'])
-            logging.INFO(f"Quantidade comprada: {Quantity}")
-            logging.INFO(order_)
+            logger.info(f"Quantidade comprada: {Quantity}")
+            logger.info(order_)
 
         except BinanceAPIException as e:
-            logging.exception(f"Erro da Binance, status code {e.status_code}. Traceback abaixo.")
+            logger.exception(f"Erro da Binance, status code {e.status_code}. Traceback abaixo.")
             Aviso.emit(e.message)
         
         Aviso_quantidade.emit(str(Quantity))
@@ -172,13 +173,13 @@ def Trade_bot(Aviso_valor_atual,Set_status,Aviso_valor,Aviso_quantidade,Aviso,cl
                                         trades_finalizados,today)
             Aviso_valor.emit('Valor de venda: '+str(valor_de_venda))
             Set_status.emit(3)
-            logging.INFO("Esperando oportunidade de compra")
+            logger.info("Esperando oportunidade de compra")
             Aviso.emit('Esperando oportunidade de compra')
             Set_status.emit(1)
             tradingview.interval=temp 
             
         if espera==False:
-            logging.INFO("Esperando ativo valorizar mais")
+            logger.info("Esperando ativo valorizar mais")
             Aviso.emit('Esperando ativo valorizar mais')
             status_trade=recommendation
             Set_Button_Venda.emit(True)
@@ -186,7 +187,7 @@ def Trade_bot(Aviso_valor_atual,Set_status,Aviso_valor,Aviso_quantidade,Aviso,cl
         espera=True
     elif 'BUY' in recommendation and 'NEUTRAL' in status_trade and Venda_lucro==False:
             if espera==False:
-                logging.INFO("Ativo muito valorizado, estou esperando oportunidade de compra")
+                logger.info("Ativo muito valorizado, estou esperando oportunidade de compra")
                 Aviso.emit('Ativo muito valorizado, estou esperando oportunidade de compra')
                 Set_status.emit(1)
             espera=True
@@ -223,17 +224,17 @@ def main(Set_status,Aviso,client_binance,Crypto,investimento_max,Quantity):
             #Quantity=round(Quantity)
             
 
-    logging.INFO(f"Quantidade:: {Quantity}")
+    logger.info(f"Quantidade:: {Quantity}")
     if 'USDT' in Crypto   and float(saldo_usdt['free']) > 1 and valor_do_trade>10:
-         logging.INFO(f"Iniciando o trade de: {Crypto}, com valor de caixa de: {valor_do_trade}")
+         logger.info(f"Iniciando o trade de: {Crypto}, com valor de caixa de: {valor_do_trade}")
          Trade=True
          #Trade_bot(Crypto,Quantity)
     elif 'BTC' in Crypto   and float(saldo_btc['free']) > 0:
-         logging.INFO(f"Iniciando o trade de: {Crypto}, com valor de caixa de: {valor_do_trade}")
+         logger.info(f"Iniciando o trade de: {Crypto}, com valor de caixa de: {valor_do_trade}")
          Trade=True
          #Trade_bot(Crypto,Quantity)
     else: 
-        logging.WARNING("Saldo insuficiente ou o tamanho da ordem é menor que 10$ usdt ou o par não é com USDT")
+        logger.warning("Saldo insuficiente ou o tamanho da ordem é menor que 10$ usdt ou o par não é com USDT")
         Aviso.emit('Saldo insuficiente' )
         Set_status.emit(1)
         Trade= False

--- a/functions.py
+++ b/functions.py
@@ -24,12 +24,15 @@ import pandas as pd
 from math import floor, log
 
 import logging
-
+logging.basicConfig(
+    format='%(asctime)s %(levelname)-8s %(message)s',
+    level=logging.INFO,
+    datefmt='%Y-%m-%d %H:%M:%S')
 logger = logging.getLogger("Trading Bot")
 
 
-def Map(x, in_min, in_max, out_min, out_max):
-    return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min
+def Map(x, in_min, in_max, out_min, out_max) -> int:
+    return int ( (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min )
 
 
 def Sentimento_do_mercado(investimento_max):

--- a/main_unit.py
+++ b/main_unit.py
@@ -1,11 +1,13 @@
 import sys
 from PyQt5 import QtCore, QtGui, QtWidgets, uic
 import numpy as np
+
 # Importar bibliotecas necessárias da thread
 import threading
 import time
+
 # Importar bibliotecas necessárias da binance
-from binance.exceptions import BinanceAPIException # here
+from binance.exceptions import BinanceAPIException  # here
 from binance.helpers import round_step_size
 from binance.client import Client
 from binance.enums import *
@@ -18,72 +20,77 @@ import pytz
 import json
 
 import logging
-logger = logging.getLogger('Trading Bot')
 
-credentials =  json.load(open(f"./credentials.json"))
-client_binance= Client(api_key=credentials.get("API_KEY"), api_secret=credentials.get("API_SECRET"))
+logger = logging.getLogger("Trading Bot")
+
+credentials = json.load(open(f"./credentials.json"))
+client_binance = Client(
+    api_key=credentials.get("API_KEY"), api_secret=credentials.get("API_SECRET")
+)
 
 
-class Main(QtWidgets.QMainWindow):     
+class Main(QtWidgets.QMainWindow):
     global client_binance
- 
-    def __init__(self,parent=None):
-        super(Main, self).__init__(parent) # Call the inherited classes __init__ method
-        uic.loadUi('trade_manage_unit.ui', self) # Load the .ui file
 
-        #Atribuição de funções
-        self.percentage.setText('0')
-        #self.text = self.findChild(QtWidgets.QTextBrowser, 'textBrowser')
-        #self.textBrowser.setText('OI')
-        self.text = self.findChild(QtWidgets.QLabel, 'percentage')
-        self.recommendation = self.findChild(QtWidgets.QLabel, 'recommendation')
-        self.aviso = self.findChild(QtWidgets.QLabel, 'aviso')
-        self.aviso_valor= self.findChild(QtWidgets.QLabel, 'aviso_valor')
-        self.aviso_valor_atual= self.findChild(QtWidgets.QLabel, 'aviso_valor_atual')
-        self.aviso_valor_quantidade= self.findChild(QtWidgets.QLabel, 'aviso_valor_quantidade')
+    def __init__(self, parent=None):
+        super(Main, self).__init__(parent)  # Call the inherited classes __init__ method
+        uic.loadUi("trade_manage_unit.ui", self)  # Load the .ui file
 
-        self.venda=False
+        # Atribuição de funções
+        self.percentage.setText("0")
+        # self.text = self.findChild(QtWidgets.QTextBrowser, 'textBrowser')
+        # self.textBrowser.setText('OI')
+        self.text = self.findChild(QtWidgets.QLabel, "percentage")
+        self.recommendation = self.findChild(QtWidgets.QLabel, "recommendation")
+        self.aviso = self.findChild(QtWidgets.QLabel, "aviso")
+        self.aviso_valor = self.findChild(QtWidgets.QLabel, "aviso_valor")
+        self.aviso_valor_atual = self.findChild(QtWidgets.QLabel, "aviso_valor_atual")
+        self.aviso_valor_quantidade = self.findChild(
+            QtWidgets.QLabel, "aviso_valor_quantidade"
+        )
+
+        self.venda = False
         self.pushButton_venda.setEnabled(False)
         self.pushButton_venda.clicked.connect(self.Venda)
-
 
         self.pushButton_compra.setEnabled(False)
         self.pushButton_compra.clicked.connect(self.Compra)
 
-        #self.aviso_valor.setText('oi')
+        # self.aviso_valor.setText('oi')
         self.checkBox_trade.clicked.connect(self.Life_bot)
-        self.Grafik = self.findChild(QtWidgets.QGraphicsView, 'graphicsView_1')
-        #Chama a função do grafico e recebe o atributo item para definir o valor
+        self.Grafik = self.findChild(QtWidgets.QGraphicsView, "graphicsView_1")
+        # Chama a função do grafico e recebe o atributo item para definir o valor
         self.item = self.grafico_rentabilidade(self.Grafik)
-    
-        self.show() # Show the GUI
+
+        self.show()  # Show the GUI
 
     def Venda(self):
         self.pushButton_venda.setEnabled(False)
         logger.info("apertou vender")
         self.pushButton_venda.setDisabled(True)
-        #self.pushButton_compra.setEnabled(False)
+        # self.pushButton_compra.setEnabled(False)
         self.t.event_Venda()
-        #self.Life_bot()
+        # self.Life_bot()
+
     def Compra(self):
         self.pushButton_compra.setEnabled(False)
         logger.info("apertou comprar")
         self.pushButton_compra.setDisabled(True)
-        #self.pushButton_compra.setEnabled(False)
+        # self.pushButton_compra.setEnabled(False)
         self.t.event_Compra()
-        #self.Life_bot()
+        # self.Life_bot()
 
-    def grafico_rentabilidade(self,Grafik):
-        #Configuração do ponteiro
+    def grafico_rentabilidade(self, Grafik):
+        # Configuração do ponteiro
         pen = QtGui.QPen(QtCore.Qt.white)
         pen.setWidth(4)
-        pen.setCapStyle(QtCore.Qt.RoundCap)    
+        pen.setCapStyle(QtCore.Qt.RoundCap)
         scene = QtWidgets.QGraphicsScene()
-        pen.setCosmetic(True)  
+        pen.setCosmetic(True)
 
-        #adc a imagem de fundo
-        scene.addPixmap(QtGui.QPixmap('bitmap.png'))
-        item = scene.addLine(70, 160,87, 87, pen)   
+        # adc a imagem de fundo
+        scene.addPixmap(QtGui.QPixmap("bitmap.png"))
+        item = scene.addLine(70, 160, 87, 87, pen)
         pen = QtGui.QPen(QtGui.QColor(QtCore.Qt.yellow))
         brush = QtGui.QBrush(QtCore.Qt.gray)
         scene.addEllipse(77, 77, 20, 20, pen, brush)
@@ -92,15 +99,16 @@ class Main(QtWidgets.QMainWindow):
         Grafik.setScene(scene)
         Grafik.setCacheMode(QtWidgets.QGraphicsView.CacheBackground)
         return item
-    def set_Status(self,val):
-        if val==1:
+
+    def set_Status(self, val):
+        if val == 1:
             self.radioButton_comprado.setChecked(False)
             self.radioButton_comprado.setDisabled(True)
             self.radioButton_vendido.setChecked(False)
             self.radioButton_vendido.setDisabled(True)
             self.radioButton_espera.setChecked(True)
             self.radioButton_espera.setDisabled(True)
-        elif val==2:
+        elif val == 2:
             self.radioButton_comprado.setChecked(True)
             self.radioButton_comprado.setDisabled(True)
             self.radioButton_vendido.setChecked(False)
@@ -108,7 +116,7 @@ class Main(QtWidgets.QMainWindow):
             self.radioButton_espera.setChecked(False)
             self.radioButton_espera.setDisabled(True)
 
-        elif val==3:
+        elif val == 3:
             self.radioButton_comprado.setChecked(False)
             self.radioButton_comprado.setDisabled(True)
             self.radioButton_vendido.setChecked(True)
@@ -116,7 +124,7 @@ class Main(QtWidgets.QMainWindow):
             self.radioButton_espera.setChecked(False)
             self.radioButton_espera.setDisabled(True)
 
-        elif val==4:
+        elif val == 4:
             self.radioButton_comprado.setDisabled(False)
             self.radioButton_comprado.setChecked(False)
 
@@ -129,16 +137,16 @@ class Main(QtWidgets.QMainWindow):
     def Life_bot(self):
         if self.checkBox_trade.isChecked():
             self.set_Status(1)
-            Crypto= self.Crypto.text()
+            Crypto = self.Crypto.text()
             time = self.Tempo_grafico.text()
-            valor_de_caixa= self.valor_de_caixa.text()
+            valor_de_caixa = self.valor_de_caixa.text()
             if self.checkBox_sentimento.isChecked():
-                valor_de_caixa=Trade_bot.Sentimento_do_mercado(float(valor_de_caixa))
+                valor_de_caixa = Trade_bot.Sentimento_do_mercado(float(valor_de_caixa))
                 self.valor_de_caixa.setText(str(valor_de_caixa))
             else:
-                valor_de_caixa=float(valor_de_caixa)
-    
-            self.t = wait_trade(client_binance,Crypto,time,valor_de_caixa)
+                valor_de_caixa = float(valor_de_caixa)
+
+            self.t = wait_trade(client_binance, Crypto, time, valor_de_caixa)
 
             self.t.PRINT.connect(self.text.setText)
             self.t.Recommendation_text.connect(self.recommendation.setText)
@@ -150,17 +158,18 @@ class Main(QtWidgets.QMainWindow):
             self.t.Set_Button_Venda.connect(self.pushButton_venda.setEnabled)
             self.t.Set_Button_Compra.connect(self.pushButton_compra.setEnabled)
             self.t.Aviso_quantidade.connect(self.aviso_valor_quantidade.setText)
-            
-            #self.t.run(self.text)
-            #self.t.begin() 
-            self.t.start()  
-            #if self.venda:
+
+            # self.t.run(self.text)
+            # self.t.begin()
+            self.t.start()
+            # if self.venda:
             #  print('iniciando evento de venda')
-            #  self.t.event_Venda()  
+            #  self.t.event_Venda()
             #  self.venda=False
 
         else:
-            self.t.kill() 
+            self.t.kill()
+
 
 class wait_trade(QtCore.QObject):
     PRINT = QtCore.pyqtSignal(str)
@@ -168,33 +177,33 @@ class wait_trade(QtCore.QObject):
     Aviso = QtCore.pyqtSignal(str)
     Aviso_valor = QtCore.pyqtSignal(str)
     Aviso_valor_atual = QtCore.pyqtSignal(str)
-    Rotation= QtCore.pyqtSignal(int)
-    Set_status= QtCore.pyqtSignal(int)
-    Set_Button_Venda= QtCore.pyqtSignal(bool)
-    Set_Button_Compra= QtCore.pyqtSignal(bool)
-    Aviso_quantidade=QtCore.pyqtSignal(str)
-    def __init__(self,client_binance,Crypto,temp,valor_de_caixa):
+    Rotation = QtCore.pyqtSignal(int)
+    Set_status = QtCore.pyqtSignal(int)
+    Set_Button_Venda = QtCore.pyqtSignal(bool)
+    Set_Button_Compra = QtCore.pyqtSignal(bool)
+    Aviso_quantidade = QtCore.pyqtSignal(str)
+
+    def __init__(self, client_binance, Crypto, temp, valor_de_caixa):
         super().__init__()
-        self.Intervals=['1m','5m','15m','30m','1h','2h','4h','1d','1W','1M']
-        self.recommendation='NEUTRAL'
-        self.status_trade='NEUTRAL'
-        self.preco_atual=0
-        self.porcentagem=0
-        self.investimento_max=valor_de_caixa
-        self.temp=temp
-        self.time_atual=10
+        self.Intervals = ["1m", "5m", "15m", "30m", "1h", "2h", "4h", "1d", "1W", "1M"]
+        self.recommendation = "NEUTRAL"
+        self.status_trade = "NEUTRAL"
+        self.preco_atual = 0
+        self.porcentagem = 0
+        self.investimento_max = valor_de_caixa
+        self.temp = temp
+        self.time_atual = 10
         self._kill = threading.Event()
         self.client_binance = client_binance
         self.Crypto = Crypto
-        self.venda=False
-        self.compra=False
-        
+        self.venda = False
+        self.compra = False
 
-        self.T_br = pytz.timezone('America/Sao_Paulo')
+        self.T_br = pytz.timezone("America/Sao_Paulo")
         self.today = datetime.now(self.T_br)
-        
-        self.t= threading.Timer(self.time_atual, self._execute)
-    
+
+        self.t = threading.Timer(self.time_atual, self._execute)
+
     def begin(self):
 
         self.Set_Button_Venda.emit(False)
@@ -203,183 +212,260 @@ class wait_trade(QtCore.QObject):
         if self.temp in self.Intervals:
             pass
         else:
-            self.temp='1h'
+            self.temp = "1h"
 
         self.tradingview = TA_Handler(
-        symbol=self.Crypto,
-        screener="crypto",
-        exchange="BINANCE",
-        interval=self.temp,
-        timeout=(30)
+            symbol=self.Crypto,
+            screener="crypto",
+            exchange="BINANCE",
+            interval=self.temp,
+            timeout=(30),
         )
 
-        self.arquivo= 'trades_finalizados_'+self.Crypto+'.csv'
+        self.arquivo = "trades_finalizados_" + self.Crypto + ".csv"
         if os.path.isfile(self.arquivo):
-            self.trades_finalizados=pd.read_csv(self.arquivo,index_col=False) 
+            self.trades_finalizados = pd.read_csv(self.arquivo, index_col=False)
         else:
             logger.info(f"Criando base de dados para: {self.Crypto}")
             dia = self.today.strftime("%d/%m/%Y")
             horario = self.today.strftime("%H:%M:%S")
-            data_pd={'Crypto':[self.Crypto],'Status':['NEUTRAL'],'Price':[0],'Quantity':[0],'Day':[dia],'HOUR':[horario]}
-            self.trades_finalizados=pd.DataFrame(data_pd)
+            data_pd = {
+                "Crypto": [self.Crypto],
+                "Status": ["NEUTRAL"],
+                "Price": [0],
+                "Quantity": [0],
+                "Day": [dia],
+                "HOUR": [horario],
+            }
+            self.trades_finalizados = pd.DataFrame(data_pd)
             self.trades_finalizados.to_csv(self.arquivo, index=False)
-            
-        self.status_trade=self.trades_finalizados['Status'][self.trades_finalizados.index[-1]]
+
+        self.status_trade = self.trades_finalizados["Status"][
+            self.trades_finalizados.index[-1]
+        ]
         logger.info(f"último status:  {self.status_trade}")
-        if 'BUY' in self.status_trade:
-            self.valor_de_compra=self.trades_finalizados['Price'][self.trades_finalizados.index[-1]]
-            self.Aviso_valor.emit('Valor de Compra: ' + str(self.valor_de_compra))
-            self.valor_de_venda=0;
-            self.Quantity=self.trades_finalizados['Quantity'][self.trades_finalizados.index[-1]]
-            #self.Quantity=0
+        if "BUY" in self.status_trade:
+            self.valor_de_compra = self.trades_finalizados["Price"][
+                self.trades_finalizados.index[-1]
+            ]
+            self.Aviso_valor.emit("Valor de Compra: " + str(self.valor_de_compra))
+            self.valor_de_venda = 0
+            self.Quantity = self.trades_finalizados["Quantity"][
+                self.trades_finalizados.index[-1]
+            ]
+            # self.Quantity=0
             self.Aviso_quantidade.emit(str(self.Quantity))
 
-            self.Venda_lucro=False
+            self.Venda_lucro = False
             self.Set_status.emit(2)
         else:
-            self.valor_de_venda=self.trades_finalizados['Price'][self.trades_finalizados.index[-1]]
-            #self.Quantity=self.trades_finalizados['Quantity'][self.trades_finalizados.index[-1]]
-            self.Quantity=0
+            self.valor_de_venda = self.trades_finalizados["Price"][
+                self.trades_finalizados.index[-1]
+            ]
+            # self.Quantity=self.trades_finalizados['Quantity'][self.trades_finalizados.index[-1]]
+            self.Quantity = 0
             self.Aviso_quantidade.emit(str(self.Quantity))
-            self.valor_de_compra=0;
-            self.Venda_lucro=False
+            self.valor_de_compra = 0
+            self.Venda_lucro = False
             self.Set_status.emit(3)
-            self.status_trade='NEUTRAL'
+            self.status_trade = "NEUTRAL"
             self.Set_Button_Compra.emit(True)
 
-        self.espera=False
+        self.espera = False
 
     def start(self):
-        #threading.Timer(5, self._execute).start()
+        # threading.Timer(5, self._execute).start()
         self.t.start()
 
-    def _execute(self):  
+    def _execute(self):
         self.begin()
-        self.Quantity, self.Trade, self.preco_medio = Trade_bot.main(self.Set_status,self.Aviso,self.client_binance,self.Crypto,self.investimento_max,self.Quantity)
-        #self.Aviso_quantidade.emit(str(self.Quantity))
+        self.Quantity, self.Trade, self.preco_medio = Trade_bot.main(
+            self.Set_status,
+            self.Aviso,
+            self.client_binance,
+            self.Crypto,
+            self.investimento_max,
+            self.Quantity,
+        )
+        # self.Aviso_quantidade.emit(str(self.Quantity))
         logger.info(f"Quantidade: {str(self.Quantity)}")
-       # try:
+        # try:
         while True:
             if self.Trade:
-                    self.Quantity,self.recommendation, self.status_trade, self.Trade, self.preco_atual, self.porcentagem,self.Venda_lucro, self.espera, self.valor_de_compra, self.tradingview= Trade_bot.Trade_bot(self.Aviso_valor_atual,self.Set_status,self.Aviso_valor,self.Aviso_quantidade,
-                                                                                                                                                                                                                    self.Aviso,self.client_binance,self.Crypto,self.Quantity,self.preco_atual,self.temp,
-                                                                                                                                                                                                                    self.today,self.tradingview, self.Venda_lucro, self.recommendation,self.arquivo, self.espera, 
-                                                                                                                                                                                                                    self.status_trade, self.trades_finalizados, self.valor_de_compra, self.valor_de_venda,self.Trade,self.porcentagem,self.Set_Button_Venda)
-                    value=self.porcentagem
-                    self.Recommendation_text.emit(self.recommendation)
-                    value_map=Trade_bot.Map(value,-20,20,50,288)
-                    self.PRINT.emit(str(np.round(value,1))+'%')
-                    self.Rotation.emit(value_map)
-                    time.sleep(self.time_atual)
-                    #time.sleep(60)
+                (
+                    self.Quantity,
+                    self.recommendation,
+                    self.status_trade,
+                    self.Trade,
+                    self.preco_atual,
+                    self.porcentagem,
+                    self.Venda_lucro,
+                    self.espera,
+                    self.valor_de_compra,
+                    self.tradingview,
+                ) = Trade_bot.Trade_bot(
+                    self.Aviso_valor_atual,
+                    self.Set_status,
+                    self.Aviso_valor,
+                    self.Aviso_quantidade,
+                    self.Aviso,
+                    self.client_binance,
+                    self.Crypto,
+                    self.Quantity,
+                    self.preco_atual,
+                    self.temp,
+                    self.today,
+                    self.tradingview,
+                    self.Venda_lucro,
+                    self.recommendation,
+                    self.arquivo,
+                    self.espera,
+                    self.status_trade,
+                    self.trades_finalizados,
+                    self.valor_de_compra,
+                    self.valor_de_venda,
+                    self.Trade,
+                    self.porcentagem,
+                    self.Set_Button_Venda,
+                )
+                value = self.porcentagem
+                self.Recommendation_text.emit(self.recommendation)
+                value_map = Trade_bot.Map(value, -20, 20, 50, 288)
+                self.PRINT.emit(str(np.round(value, 1)) + "%")
+                self.Rotation.emit(value_map)
+                time.sleep(self.time_atual)
+                # time.sleep(60)
             else:
-                    self.Quantity, self.Trade, self.preco_medio = Trade_bot.main(self.Set_status,self.Aviso,self.client_binance,self.Crypto,self.investimento_max,self.Quantity)
-                    time.sleep(20)
+                self.Quantity, self.Trade, self.preco_medio = Trade_bot.main(
+                    self.Set_status,
+                    self.Aviso,
+                    self.client_binance,
+                    self.Crypto,
+                    self.investimento_max,
+                    self.Quantity,
+                )
+                time.sleep(20)
 
             if self.venda == True:
-                    logger.info("Ativo vendido!")
-                    self.venda=False
-                    self.Set_Button_Venda.emit(False)
-                    self.Set_Button_Compra.emit(True)
-            if self.compra == True: 
-                    logger.info("Ativo comprado!")
-                    self.compra=False
-                    #self.Set_Button_Venda.emit(True)
-                    self.Set_Button_Compra.emit(False)
-                    
+                logger.info("Ativo vendido!")
+                self.venda = False
+                self.Set_Button_Venda.emit(False)
+                self.Set_Button_Compra.emit(True)
+            if self.compra == True:
+                logger.info("Ativo comprado!")
+                self.compra = False
+                # self.Set_Button_Venda.emit(True)
+                self.Set_Button_Compra.emit(False)
 
-                
             if self._kill.is_set() == True:
                 break
-       # except: 
-        #    print('reiniciando a thread')
-         #   self.t= threading.Timer(self.time_atual, self._execute)
+
+    # except:
+    #    print('reiniciando a thread')
+    #   self.t= threading.Timer(self.time_atual, self._execute)
 
     def event_Venda(self):
-        self.venda=True
+        self.venda = True
         logger.info("venda autorizada")
         try:
-                    self.Venda_lucro=True
-                    self.status_trade='NEUTRAL'
-                    self.valor_de_venda, self.porcentagem = Trade_bot.Venda_trade(self.arquivo,self.client_binance,self.Crypto,
-                                                self.Quantity,'SELL',self.valor_de_compra,
-                                                self.trades_finalizados,self.today)
-                    self.Aviso_valor.emit('Valor de venda: '+str(self.valor_de_venda))
-                    self.Set_status.emit(3)
-                    #self.Aviso_quantidade.emit(str(0))
-                    logger.info('Esperando oportunidade de compra')
-                    self.Aviso.emit('Esperando oportunidade de compra')
-                    self.Set_status.emit(1)
-                    self.tradingview.interval=self.temp 
+            self.Venda_lucro = True
+            self.status_trade = "NEUTRAL"
+            self.valor_de_venda, self.porcentagem = Trade_bot.Venda_trade(
+                self.arquivo,
+                self.client_binance,
+                self.Crypto,
+                self.Quantity,
+                "SELL",
+                self.valor_de_compra,
+                self.trades_finalizados,
+                self.today,
+            )
+            self.Aviso_valor.emit("Valor de venda: " + str(self.valor_de_venda))
+            self.Set_status.emit(3)
+            # self.Aviso_quantidade.emit(str(0))
+            logger.info("Esperando oportunidade de compra")
+            self.Aviso.emit("Esperando oportunidade de compra")
+            self.Set_status.emit(1)
+            self.tradingview.interval = self.temp
 
-                    self.Set_Button_Venda.emit(False)
-                    self.Set_Button_Compra.emit(True)
+            self.Set_Button_Venda.emit(False)
+            self.Set_Button_Compra.emit(True)
 
         except BinanceAPIException as e:
-                    self.Aviso.emit(e.message)
+            self.Aviso.emit(e.message)
 
     def event_Compra(self):
-        self.compra=True
+        self.compra = True
         logger.info("Compra Autorizada")
         try:
-                    self.Venda_lucro=False
-                    self.status_trade='BUY'
-                    #faz a compra
+            self.Venda_lucro = False
+            self.status_trade = "BUY"
+            # faz a compra
 
-                    #self.Aviso_valor.emit('Valor de compra '+str(self.valor_de_venda))
-                    #self.Set_status.emit(2)
-                    #print('Compra feita, esperando valorização')
-                    #self.Aviso.emit('Compra feita, esperando valorização')
-                    #self.tradingview.interval=self.temp 
-                    #self.Set_Button_Compra.emit(False)
-                    
-                    logger.info("Comprando ativo")
-                   
-                    order_ = self.client_binance.order_market_buy(symbol=self.Crypto,quantity=self.Quantity)
-                    self.valor_de_compra=float(order_['fills'][0]['price'])
-                    logger.info(f"Valor de compra: {self.valor_de_compra}")
-                    self.Aviso_valor.emit('Valor de compra: '+str(self.valor_de_compra))
-                    self.Set_status.emit(2)
+            # self.Aviso_valor.emit('Valor de compra '+str(self.valor_de_venda))
+            # self.Set_status.emit(2)
+            # print('Compra feita, esperando valorização')
+            # self.Aviso.emit('Compra feita, esperando valorização')
+            # self.tradingview.interval=self.temp
+            # self.Set_Button_Compra.emit(False)
 
-                    dia = self.today.strftime("%d/%m/%Y")
-                    horario = self.today.strftime("%H:%M:%S")
-                    data_pd={'Crypto':self.Crypto,'Status':self.recommendation,'Price':self.valor_de_compra,'Quantity':self.Quantity,'Day':dia,'HOUR':horario}
-                    trades_finalizados=self.trades_finalizados.append(data_pd,ignore_index=True)
-                    trades_finalizados.to_csv(self.arquivo, index=False)
-                    
-                    self.espera=False
-                    self.status_trade=self.recommendation
-                    self.Set_Button_Venda.emit(True)
-                    self.Set_Button_Compra.emit(False)
+            logger.info("Comprando ativo")
+
+            order_ = self.client_binance.order_market_buy(
+                symbol=self.Crypto, quantity=self.Quantity
+            )
+            self.valor_de_compra = float(order_["fills"][0]["price"])
+            logger.info(f"Valor de compra: {self.valor_de_compra}")
+            self.Aviso_valor.emit("Valor de compra: " + str(self.valor_de_compra))
+            self.Set_status.emit(2)
+
+            dia = self.today.strftime("%d/%m/%Y")
+            horario = self.today.strftime("%H:%M:%S")
+            data_pd = {
+                "Crypto": self.Crypto,
+                "Status": self.recommendation,
+                "Price": self.valor_de_compra,
+                "Quantity": self.Quantity,
+                "Day": dia,
+                "HOUR": horario,
+            }
+            trades_finalizados = self.trades_finalizados.append(
+                data_pd, ignore_index=True
+            )
+            trades_finalizados.to_csv(self.arquivo, index=False)
+
+            self.espera = False
+            self.status_trade = self.recommendation
+            self.Set_Button_Venda.emit(True)
+            self.Set_Button_Compra.emit(False)
 
         except BinanceAPIException as e:
             # loga no console
             logger.exception(f"Erro de status code {e.status_code}. Traceback abaixo.")
             self.Aviso.emit(e.message)
-                    
-        try: 
-                logger.info(f"Quantidade: {float(order_['origQty'])}")
-                Quantity=float(order_['executedQty'])
-                logger.info(f"Quantidade comprada: {self.Quantity}")
-                logger.info(order_)
+
+        try:
+            logger.info(f"Quantidade: {float(order_['origQty'])}")
+            Quantity = float(order_["executedQty"])
+            logger.info(f"Quantidade comprada: {self.Quantity}")
+            logger.info(order_)
 
         except BinanceAPIException as e:
             # loga no console
             logger.exception(f"Erro de status code {e.status_code}. Traceback abaixo.")
             self.Aviso.emit(e.message)
-        
+
         self.Aviso_quantidade.emit(str(self.Quantity))
-                    
 
     def kill(self):
         self._kill.set()
         self.t.cancel()
-        print('Afunção morreu')
-    
-   
-if __name__ == '__main__' :
-    app = QtWidgets.QApplication(sys.argv)  
-    #window = Upload_window()
+        print("Afunção morreu")
+
+
+if __name__ == "__main__":
+    app = QtWidgets.QApplication(sys.argv)
+    # window = Upload_window()
     window = Main()
     window.show()
     sys.exit(app.exec_())

--- a/main_unit.py
+++ b/main_unit.py
@@ -15,11 +15,11 @@ import os.path
 import pandas as pd
 from datetime import datetime
 import pytz
-import config_My_API
+import json
 
 
-
-client_binance= Client(api_key=config_My_API.api_key, api_secret=config_My_API.api_secret)
+credentials =  json.load(open(f"./credentials.json"))
+client_binance= Client(api_key=credentials.get("API_KEY"), api_secret=credentials.get("API_SECRET"))
 
 
 class Main(QtWidgets.QMainWindow):     

--- a/main_unit.py
+++ b/main_unit.py
@@ -19,18 +19,14 @@ from datetime import datetime
 import pytz
 import json
 
-import logging
-logging.basicConfig(
-    format='%(asctime)s %(levelname)-8s %(message)s',
-    level=logging.INFO,
-    datefmt='%Y-%m-%d %H:%M:%S')
-logger = logging.getLogger("Trading Bot")
+from coloredlogs import CustomFormatter
+logger = CustomFormatter().get_colored_logger()
+
 
 credentials = json.load(open(f"./credentials.json"))
 client_binance = Client(
     api_key=credentials.get("API_KEY"), api_secret=credentials.get("API_SECRET")
 )
-
 
 class Main(QtWidgets.QMainWindow):
     global client_binance
@@ -246,7 +242,7 @@ class wait_trade(QtCore.QObject):
         self.status_trade = self.trades_finalizados["Status"][
             self.trades_finalizados.index[-1]
         ]
-        logger.info(f"último status:  {self.status_trade}")
+        logger.warning(f"último status:  {self.status_trade}")
         if "BUY" in self.status_trade:
             self.valor_de_compra = self.trades_finalizados["Price"][
                 self.trades_finalizados.index[-1]

--- a/main_unit.py
+++ b/main_unit.py
@@ -18,7 +18,7 @@ import pytz
 import config_My_API
 
 import logging
-
+logger = logging.getLogger('Trading Bot')
 
 client_binance= Client(api_key=config_My_API.api_key, api_secret=config_My_API.api_secret)
 
@@ -59,14 +59,14 @@ class Main(QtWidgets.QMainWindow):
 
     def Venda(self):
         self.pushButton_venda.setEnabled(False)
-        logging.INFO("apertou vender")
+        logger.info("apertou vender")
         self.pushButton_venda.setDisabled(True)
         #self.pushButton_compra.setEnabled(False)
         self.t.event_Venda()
         #self.Life_bot()
     def Compra(self):
         self.pushButton_compra.setEnabled(False)
-        logging.INFO("apertou comprar")
+        logger.info("apertou comprar")
         self.pushButton_compra.setDisabled(True)
         #self.pushButton_compra.setEnabled(False)
         self.t.event_Compra()
@@ -216,7 +216,7 @@ class wait_trade(QtCore.QObject):
         if os.path.isfile(self.arquivo):
             self.trades_finalizados=pd.read_csv(self.arquivo,index_col=False) 
         else:
-            logging.INFO(f"Criando base de dados para: {self.Crypto}")
+            logger.info(f"Criando base de dados para: {self.Crypto}")
             dia = self.today.strftime("%d/%m/%Y")
             horario = self.today.strftime("%H:%M:%S")
             data_pd={'Crypto':[self.Crypto],'Status':['NEUTRAL'],'Price':[0],'Quantity':[0],'Day':[dia],'HOUR':[horario]}
@@ -224,7 +224,7 @@ class wait_trade(QtCore.QObject):
             self.trades_finalizados.to_csv(self.arquivo, index=False)
             
         self.status_trade=self.trades_finalizados['Status'][self.trades_finalizados.index[-1]]
-        logging.INFO(f"último status:  {self.status_trade}")
+        logger.info(f"último status:  {self.status_trade}")
         if 'BUY' in self.status_trade:
             self.valor_de_compra=self.trades_finalizados['Price'][self.trades_finalizados.index[-1]]
             self.Aviso_valor.emit('Valor de Compra: ' + str(self.valor_de_compra))
@@ -256,7 +256,7 @@ class wait_trade(QtCore.QObject):
         self.begin()
         self.Quantity, self.Trade, self.preco_medio = Trade_bot.main(self.Set_status,self.Aviso,self.client_binance,self.Crypto,self.investimento_max,self.Quantity)
         #self.Aviso_quantidade.emit(str(self.Quantity))
-        logging.INFO(f"Quantidade: {str(self.Quantity)}")
+        logger.info(f"Quantidade: {str(self.Quantity)}")
        # try:
         while True:
             if self.Trade:
@@ -276,12 +276,12 @@ class wait_trade(QtCore.QObject):
                     time.sleep(20)
 
             if self.venda == True:
-                    logging.INFO("Ativo vendido!")
+                    logger.info("Ativo vendido!")
                     self.venda=False
                     self.Set_Button_Venda.emit(False)
                     self.Set_Button_Compra.emit(True)
             if self.compra == True: 
-                    logging.INFO("Ativo comprado!")
+                    logger.info("Ativo comprado!")
                     self.compra=False
                     #self.Set_Button_Venda.emit(True)
                     self.Set_Button_Compra.emit(False)
@@ -296,7 +296,7 @@ class wait_trade(QtCore.QObject):
 
     def event_Venda(self):
         self.venda=True
-        logging.INFO("venda autorizada")
+        logger.info("venda autorizada")
         try:
                     self.Venda_lucro=True
                     self.status_trade='NEUTRAL'
@@ -306,7 +306,7 @@ class wait_trade(QtCore.QObject):
                     self.Aviso_valor.emit('Valor de venda: '+str(self.valor_de_venda))
                     self.Set_status.emit(3)
                     #self.Aviso_quantidade.emit(str(0))
-                    logging.INFO('Esperando oportunidade de compra')
+                    logger.info('Esperando oportunidade de compra')
                     self.Aviso.emit('Esperando oportunidade de compra')
                     self.Set_status.emit(1)
                     self.tradingview.interval=self.temp 
@@ -319,7 +319,7 @@ class wait_trade(QtCore.QObject):
 
     def event_Compra(self):
         self.compra=True
-        logging.INFO("Compra Autorizada")
+        logger.info("Compra Autorizada")
         try:
                     self.Venda_lucro=False
                     self.status_trade='BUY'
@@ -332,11 +332,11 @@ class wait_trade(QtCore.QObject):
                     #self.tradingview.interval=self.temp 
                     #self.Set_Button_Compra.emit(False)
                     
-                    logging.INFO("Comprando ativo")
+                    logger.info("Comprando ativo")
                    
                     order_ = self.client_binance.order_market_buy(symbol=self.Crypto,quantity=self.Quantity)
                     self.valor_de_compra=float(order_['fills'][0]['price'])
-                    logging.INFO(f"Valor de compra: {self.valor_de_compra}")
+                    logger.info(f"Valor de compra: {self.valor_de_compra}")
                     self.Aviso_valor.emit('Valor de compra: '+str(self.valor_de_compra))
                     self.Set_status.emit(2)
 
@@ -353,18 +353,18 @@ class wait_trade(QtCore.QObject):
 
         except BinanceAPIException as e:
             # loga no console
-            logging.exception(f"Erro de status code {e.status_code}. Traceback abaixo.")
+            logger.exception(f"Erro de status code {e.status_code}. Traceback abaixo.")
             self.Aviso.emit(e.message)
                     
         try: 
-                logging.INFO(f"Quantidade: {float(order_['origQty'])}")
+                logger.info(f"Quantidade: {float(order_['origQty'])}")
                 Quantity=float(order_['executedQty'])
-                logging.INFO(f"Quantidade comprada: {self.Quantity}")
-                logging.INFO(order_)
+                logger.info(f"Quantidade comprada: {self.Quantity}")
+                logger.info(order_)
 
         except BinanceAPIException as e:
             # loga no console
-            logging.exception(f"Erro de status code {e.status_code}. Traceback abaixo.")
+            logger.exception(f"Erro de status code {e.status_code}. Traceback abaixo.")
             self.Aviso.emit(e.message)
         
         self.Aviso_quantidade.emit(str(self.Quantity))

--- a/main_unit.py
+++ b/main_unit.py
@@ -20,7 +20,10 @@ import pytz
 import json
 
 import logging
-
+logging.basicConfig(
+    format='%(asctime)s %(levelname)-8s %(message)s',
+    level=logging.INFO,
+    datefmt='%Y-%m-%d %H:%M:%S')
 logger = logging.getLogger("Trading Bot")
 
 credentials = json.load(open(f"./credentials.json"))

--- a/trade_manage_unit.ui
+++ b/trade_manage_unit.ui
@@ -451,7 +451,7 @@ color: rgb(220,220,220);</string>
       <string notr="true">background-color: rgb(250, 250, 250);</string>
      </property>
      <property name="text">
-      <string>250</string>
+      <string>10</string>
      </property>
     </widget>
     <widget class="QGroupBox" name="groupBox_aviso">

--- a/trade_manage_unit.ui
+++ b/trade_manage_unit.ui
@@ -451,7 +451,7 @@ color: rgb(220,220,220);</string>
       <string notr="true">background-color: rgb(250, 250, 250);</string>
      </property>
      <property name="text">
-      <string>10</string>
+      <string>12</string>
      </property>
     </widget>
     <widget class="QGroupBox" name="groupBox_aviso">

--- a/trade_manage_unit.ui
+++ b/trade_manage_unit.ui
@@ -517,7 +517,7 @@ color: rgb(220,220,220);</string>
       <string>sentimento do mercado</string>
      </property>
      <property name="checked">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
     </widget>
     <widget class="QPushButton" name="pushButton_venda">


### PR DESCRIPTION
obs: revisar só depois do #1 parti dele e ele tem os commits de lá. Após mergear o #1, este PR terá bem menos commits para checar.

- [x] Adiciona logs colorigos com timestamps para melhorar a leitura no console
- [x] logs para warning e error são coloridos (baseado nessa [thread](https://stackoverflow.com/questions/28330317/print-timestamp-for-logging-in-python/44175370#:~:text=Before%20the%20first%20time%20you%20log%20anything%20do%20this%3A)) 
- [x] Define o padrão quando abre uma janela com 12 USDT de caixa (10 + gordura), para não ficar alto, e check de sentimento de mercado como false.